### PR TITLE
Filter empty words

### DIFF
--- a/scrollreading.js
+++ b/scrollreading.js
@@ -22,6 +22,17 @@ const throttle = (func, limit) => {
     };
 };
 
+const isPunctuation = (word) => {
+    if (word.length > 1) return false;
+    const punctuations = ".,;?:!";
+    return punctuations.indexOf(word) !== -1;
+}
+
+const getStringBetweenTag = (string) => {
+    const regex = /<([\w]+)[^>]*>(.*?)<\/\1>/
+    return string.match(regex)[2];
+}
+
 const activeScrollReader = () => {
     if (!readingMode) {
         readingMode = true;
@@ -32,7 +43,15 @@ const activeScrollReader = () => {
             for (let i = 0; i < contents.length; i++) {
                 let elem = contents[i];
                 if (elem.nodeName === "#text") {
-                    let text = $(elem).text().split(/(?=\.\s|,\s|;\s|\?\s|\!\s)/g).reduce((words, word) => {
+                    let text = $(elem).text().split(/(?=\.\s|,\s|;\s|\?\s|\!\s)/g);
+                    // the text is a punctuation then append it to the last text node
+                    if (text.length === 1 && isPunctuation(text[0])) {
+                        const lastHTML = finalHTML[finalHTML.length - 1];
+                        const lastWord = getStringBetweenTag(lastHTML);
+                        finalHTML[finalHTML.length - 1] = `<span class="scrollreading-word">${lastWord}${text}</span>`;
+                        continue;
+                    }
+                    text = text.reduce((words, word) => {
                         if (word.replace(/\s/, '').length) words.push(`<span class="scrollreading-word">${word}</span>`);
                         return words;
                     }, []).join("");

--- a/scrollreading.js
+++ b/scrollreading.js
@@ -33,12 +33,17 @@ const activeScrollReader = () => {
                 let elem = contents[i];
                 if (elem.nodeName === "#text") {
                     let text = $(elem).text().split(/(?=\.\s|,\s|;\s|\?\s|\!\s)/g).reduce((words, word) => {
-                        if (word.length) words.push(`<span class="scrollreading-word">${word}</span>`);
+                        if (word.replace(/\s/, '').length) words.push(`<span class="scrollreading-word">${word}</span>`);
                         return words;
                     }, []).join("");
                     finalHTML.push(text);
                 } else {
-                    finalHTML.push($(elem).addClass("scrollreading-word")[0].outerHTML);
+                    const isElementHasText = !!$(elem)[0].textContent
+                    const elementClassName = isElementHasText
+                        ? "scrollreading-word"
+                        : ""
+                    const element = $(elem).addClass(elementClassName)[0]
+                    finalHTML.push(element.outerHTML);
                 }
             }
             $(this).html(finalHTML.join(""));
@@ -88,6 +93,9 @@ const activeScrollReader = () => {
                     }
                 }
             }
+            if (!next.hasClass('scrollreading-word')) {
+                next = get_next(next);
+            }
             return next;
         };
 
@@ -101,6 +109,9 @@ const activeScrollReader = () => {
                         prev = elem.find(".scrollreading-word:last-child"); break;
                     }
                 }
+            }
+            if (!prev.hasClass('scrollreading-word')) {
+                prev = get_prev(prev);
             }
             return prev;
         };


### PR DESCRIPTION
This PR added a check to prevent empty words from being highlighted and also prevent the code from picking the next element which doesn't contain `scrollreading-word` class.

**Empty word cases**
1. In a `textNode` there's a `\n` character which cannot be displayed but the current code still add `scrollreading-word` class to it. Because the character can't be displayed, the highlight will disappear before re-appearing in the next highlighted word which will cause a "delay-like" effect.

2. In a `<p>` sometimes there's a `<br />` which is also can't be displayed and will cause a similar effect to the first case.

**Demonstration**

|  Before  |  After  |
|------------|----------|
|  ![before_scrollreading](https://user-images.githubusercontent.com/12984316/49843787-eaeb4400-fdf2-11e8-8a5d-02c0f8fce0a1.gif) | ![after_scrollreading](https://user-images.githubusercontent.com/12984316/49843890-5df4ba80-fdf3-11e8-89b0-06db248918d7.gif) |
| Notice the class of `<br />` and there's an empty `<span>` | No more empty `<span>` and the `<br>` is ignored |
